### PR TITLE
Remove get_status method

### DIFF
--- a/src/pybluecurrent/client.py
+++ b/src/pybluecurrent/client.py
@@ -193,11 +193,6 @@ class BlueCurrentClient:
         await self._send(dict(command="GET_SESSIONS"), token=True)
         return await self._receive("SESSIONS")
 
-    async def get_status(self, evse_id: str):
-        """Returns a useless object with evse_id and your full name"""
-        await self._send(dict(command="GET_STATUS", evse_id=evse_id), token=True)
-        return await self._receive("STATUS")
-
     async def get_sustainability_status(self) -> dict[str, float | int]:
         """
         Get statistics on the sustainability of all your charge points.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,11 +71,6 @@ class TestSocketApi:
         assert "id" in status
 
     @mark.asyncio
-    async def test_get_status(self, connected_client: BlueCurrentClient, evse_id: str):
-        status = await connected_client.get_status(evse_id=evse_id)
-        assert status["evse_id"] == evse_id
-
-    @mark.asyncio
     async def test_get_charge_point_settings(self, connected_client: BlueCurrentClient, evse_id: str):
         settings = await connected_client.get_charge_point_settings(evse_id=evse_id)
         assert isinstance(settings, dict)


### PR DESCRIPTION
The get_status method never returned anything useful, and is now returning even less:

`{"object": "STATUS", "evse_id": "", "full_name": "Your Name"}`, so the test broke.