### PR TITLE
Refactor tests and dev dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '\.(md|markdown)$'
@@ -27,7 +27,7 @@ repos:
       - id: isort
         exclude: __init__.py
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 6e63c9e
+    rev: v1.18.2
     hooks:
     -   id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["black==23.3.0", "pre-commit>=3.3.3", "pytest==8.1.2", "pytest-asyncio==0.21.1"]
+dev = ["black==23.3.0", "pre-commit>=3.3.3", "pytest==8.4.2", "pytest-asyncio==1.2.0"]
 
 [project.urls]
 Repository = "https://github.com/rogiervandergeer/pybluecurrent"
@@ -53,3 +53,8 @@ profile = "black"
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,4 +35,4 @@ async def evse_id(connected_client: BlueCurrentClient) -> str:
     charge_points = await connected_client.get_charge_points()
     if not charge_points:
         skip("No charge points available.")
-    return charge_points[0]["evse_id"]
+    return charge_points[0]["evse_id"]  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
-from asyncio import get_event_loop_policy, run
 from os import environ
 from typing import AsyncGenerator
 
 from pytest import fixture, skip
-from pytest_asyncio import fixture as async_fixture
 
 from pybluecurrent import BlueCurrentClient
 
@@ -22,14 +20,6 @@ def client_with_auth() -> BlueCurrentClient | None:
 
 
 @fixture(scope="session")
-def event_loop():
-    policy = get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@async_fixture(scope="session")
 async def connected_client() -> AsyncGenerator[BlueCurrentClient, None]:
     try:
         client = BlueCurrentClient(environ["BLUECURRENT_USERNAME"], environ["BLUECURRENT_PASSWORD"])
@@ -41,13 +31,8 @@ async def connected_client() -> AsyncGenerator[BlueCurrentClient, None]:
 
 
 @fixture(scope="session")
-def evse_id(client_with_auth: BlueCurrentClient) -> str:
-    async def _get_charge_points(client: BlueCurrentClient) -> list:
-        async with client:
-            charge_points = await client.get_charge_points()
-        return charge_points
-
-    result: list = run(_get_charge_points(client_with_auth))
-    if len(result) == 0:
+async def evse_id(connected_client: BlueCurrentClient) -> str:
+    charge_points = await connected_client.get_charge_points()
+    if not charge_points:
         skip("No charge points available.")
-    return result[0]["evse_id"]
+    return charge_points[0]["evse_id"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,12 +17,10 @@ class TestHeaders:
 
 
 class TestAuthentication:
-    @mark.asyncio
     async def test_authenticate(self, client_with_auth: BlueCurrentClient):
         async with client_with_auth:
             assert client_with_auth.token is not None
 
-    @mark.asyncio
     async def test_authentication_failed(self, client: BlueCurrentClient):
         with raises(AuthenticationFailed):
             async with client:
@@ -34,13 +32,11 @@ class TestAuthentication:
 
 
 class TestSocketApi:
-    @mark.asyncio
     async def test_get_account(self, connected_client: BlueCurrentClient):
         account = await connected_client.get_account()
         assert "full_name" in account
         assert isinstance(account["first_login_app"], date)
 
-    @mark.asyncio
     async def test_get_charge_cards(self, connected_client: BlueCurrentClient):
         charge_cards = await connected_client.get_charge_cards()
         if len(charge_cards) == 0:
@@ -56,7 +52,6 @@ class TestSocketApi:
             ]
         )
 
-    @mark.asyncio
     async def test_get_charge_points(self, connected_client: BlueCurrentClient):
         charge_points = await connected_client.get_charge_points()
         if len(charge_points) == 0:
@@ -64,41 +59,34 @@ class TestSocketApi:
         for charge_point in charge_points:
             assert "evse_id" in charge_point
 
-    @mark.asyncio
     async def test_get_grid_status(self, connected_client: BlueCurrentClient, evse_id: str):
         status = await connected_client.get_grid_status(evse_id=evse_id)
         assert "grid_actual_p1" in status
         assert "id" in status
 
-    @mark.asyncio
     async def test_get_charge_point_settings(self, connected_client: BlueCurrentClient, evse_id: str):
         settings = await connected_client.get_charge_point_settings(evse_id=evse_id)
         assert isinstance(settings, dict)
         assert settings["evse_id"] == evse_id
 
-    @mark.asyncio
     @mark.skip("Does not work")
     async def test_get_sessions(self, connected_client: BlueCurrentClient, evse_id: str):
         sessions = await connected_client.get_sessions(evse_id=evse_id)
         print(sessions)
 
-    @mark.asyncio
     async def test_get_sustainability_status(self, connected_client: BlueCurrentClient):
         sessions = await connected_client.get_sustainability_status()
         assert set(sessions.keys()) == {"trees", "co2"}
 
-    @mark.asyncio
     @mark.skip("Does not work.")
     async def test_unlock_connector(self, connected_client: BlueCurrentClient, evse_id: str):
         result = await connected_client.unlock_connector(evse_id=evse_id)
         print(result)
 
-    @mark.asyncio
     @mark.skip("Do not change chargepoint status.")
     async def test_soft_reset(self, connected_client: BlueCurrentClient, evse_id: str):
         _ = await connected_client.soft_reset(evse_id=evse_id)
 
-    @mark.asyncio
     @mark.skipif(environ.get("BLUECURRENT_READ_ONLY", "TRUE") != "FALSE", reason="Running read-only tests.")
     async def test_set_plug_and_charge_card(self, connected_client: BlueCurrentClient, evse_id: str):
         async def _get_plug_and_charge_card_uid() -> str | None:
@@ -125,7 +113,6 @@ class TestSocketApi:
         await connected_client.set_plug_and_charge_charge_card(evse_id=evse_id, uid=before_card)
         assert await _get_plug_and_charge_card_uid() == before_card
 
-    @mark.asyncio
     @mark.skipif(environ.get("BLUECURRENT_READ_ONLY", "TRUE") != "FALSE", reason="Running read-only tests.")
     async def test_set_invalid_plug_and_charge_card(self, connected_client: BlueCurrentClient, evse_id: str):
         settings = await connected_client.get_charge_point_settings(evse_id=evse_id)
@@ -133,7 +120,6 @@ class TestSocketApi:
             await connected_client.set_plug_and_charge_charge_card(evse_id=evse_id, uid="INVALID_CARD")
         assert await connected_client.get_charge_point_settings(evse_id=evse_id) == settings
 
-    @mark.asyncio
     @mark.skipif(environ.get("BLUECURRENT_READ_ONLY", "TRUE") != "FALSE", reason="Running read-only tests.")
     async def test_set_status(self, connected_client: BlueCurrentClient, evse_id: str):
         before_status = connected_client.get_charge_point_status(evse_id=evse_id)
@@ -144,7 +130,6 @@ class TestSocketApi:
         await connected_client.set_status(evse_id=evse_id, enabled=True)
         assert connected_client.get_charge_point_status(evse_id=evse_id)["activity"] == "available"
 
-    @mark.asyncio
     async def test_error(self, connected_client: BlueCurrentClient):
         with raises(BlueCurrentException) as e:
             await connected_client.set_status("BCU123456", False)


### PR DESCRIPTION
- Upgrade `pytest` to 8.4.2 and `pytest-asyncio` to 1.2.0.
- Remove unused `event_loop` fixture.
- Update test client methods to reduce redundant decorators.
- Simplify `evse_id` fixture with async handling.
- Adjust pytest configuration for asyncio compatibility.